### PR TITLE
Xcode file header

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+//  ___FILENAME___
+//  ApiKit
+//
+//  Created by Daniel Saidi on ___DATE___.
+//  Copyright © 2023 Daniel Saidi. All rights reserved.
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
makes it 
```
//
//  File.swift
//  ApiKit
//
//  Created by Daniel Saidi on 25.03.23.
//  Copyright © 2023 Daniel Saidi. All rights reserved.
//
```
for new files so you don't have to type ApiKit